### PR TITLE
feat!: prompts must now be submitted

### DIFF
--- a/src/modules/calls/calls.service.ts
+++ b/src/modules/calls/calls.service.ts
@@ -9,7 +9,7 @@ export class CallsService {
   constructor(private prisma: PrismaService) {}
 
   async create(createCallDto: CreateCallDto) {
-    const newCallPrompt = await new AI().startCall(createCallDto.character);
+    const newCallPrompt = await new AI().startCall(createCallDto.prompt);
     return this.prisma.call.create({
       data: {
         character: createCallDto.character,

--- a/src/modules/calls/dto/create-call.dto.ts
+++ b/src/modules/calls/dto/create-call.dto.ts
@@ -2,4 +2,8 @@ import { ApiProperty } from '@nestjs/swagger';
 export class CreateCallDto {
   @ApiProperty({ example: 'Galileo Galilei' })
   character: string;
+  @ApiProperty({
+    example: 'You will pretend to be Galileo Galilei. Introduce yourself.',
+  })
+  prompt: string;
 }

--- a/src/shared/ai.ts
+++ b/src/shared/ai.ts
@@ -12,8 +12,7 @@ export class AI {
     this._api = new OpenAIApi(config);
   }
 
-  async startCall(character: string) {
-    const prompt = `You must pretend to be ${character}, you know their life history and will speak in their style. Begin the conversation as you would answer a phone in your new persona.`;
+  async startCall(prompt: string) {
     const response = await this._api.createChatCompletion({
       model: 'gpt-3.5-turbo',
       messages: [


### PR DESCRIPTION
The change generalizes the `call` endpoint to accept any prompt, rather than generating it from the character. The user must now send both the `character` and the `prompt`. Currently, the `character` is unused but will be important for voice synthesis later and so is left. It is recommended to craft your prompt to contain the character and prompt for conversation.

**Example CURL:**

```sh
curl --request POST \
  --url http://timephone:3000/calls \
  --header 'Content-Type: application/json' \
  --data '{
  "character": "Galileo Galilei",
	"prompt": "You must pretend to be Galileo Galilei, you know their life history and will speak in their style. Begin the conversation as you would answer a phone in your new persona."
}'
```

**Example Response:**

```json
{
	"id": 9,
	"character": "Galileo Galilei",
	"createdAt": "2023-03-21T00:55:03.303Z",
	"prompt": "You must pretend to be Galileo Galilei, you know their life history and will speak in their style. Begin the conversation as you would answer a phone in your new persona. \nYOU: \n\n*ring, ring*\n\nGalileo: Pray, who goes there"
}
```