### PR TITLE
feat!: add prompt and response to call endpoint response

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,10 +48,11 @@ You will also get back a `prompt` which is the first response from the AI.
 
 ```json
 {
-  "id": 9,
+  "id": 11,
   "character": "Galileo Galilei",
-  "createdAt": "2023-03-21T00:55:03.303Z",
-  "prompt": "Pray, who goes there"
+  "createdAt": "2023-03-21T02:49:41.113Z",
+  "prompt": "You must pretend to be Galileo Galilei, you know their life history and will speak in their style. Begin the conversation as you would answer a phone in live conversation as your new persona. You may only speak, do not use onomatopoeia. \nYOU: \n\nGood day, this is Galileo Galilei speaking. To whom do I have the privilege of speaking",
+  "responseText": "\n\nGood day, this is Galileo Galilei speaking. To whom do I have the privilege of speaking"
 }
 ```
 

--- a/src/modules/calls/calls.service.ts
+++ b/src/modules/calls/calls.service.ts
@@ -10,14 +10,18 @@ export class CallsService {
 
   async create(createCallDto: CreateCallDto) {
     const newCallPrompt = await new AI().startCall(createCallDto.prompt);
-    return this.prisma.call.create({
+    const savedCall = await this.prisma.call.create({
       data: {
         character: createCallDto.character,
         createdAt: new Date(),
-        prompt: newCallPrompt,
+        prompt: newCallPrompt.prompt,
         },
       }
     );
+    return {
+      ...savedCall,
+      responseText: newCallPrompt.responseText,
+    };
   }
 
   findAll() {

--- a/src/shared/ai.ts
+++ b/src/shared/ai.ts
@@ -25,7 +25,10 @@ export class AI {
       stop: ['?'],
     });
     const callPrompt = `${prompt} \nYOU: ${response.data.choices[0].message.content}`;
-    return callPrompt;
+    return {
+      prompt: callPrompt,
+      responseText: response.data.choices[0].message.content,
+    };
   }
 
   // Returns a completion for an existing call with the new message


### PR DESCRIPTION
Refactor with a breaking change of the `calls` create response. The response now contains the prompt and the response separately for ease of use. The response technically becomes part of the prompt for the purposes of our bot, but we need the response separately if we intend to display it or otherwise synthesize it. We will later of course return an audio transcription as well.

```json
{
	"id": 11,
	"character": "Galileo Galilei",
	"createdAt": "2023-03-21T02:49:41.113Z",
	"prompt": "You must pretend to be Galileo Galilei, you know their life history and will speak in their style. Begin the conversation as you would answer a phone in live conversation as your new persona. You may only speak, do not use onomatopoeia. \nYOU: \n\n\"Good day, this is Galileo Galilei speaking. To whom do I have the privilege of speaking",
	"responseText": "\n\n\"Good day, this is Galileo Galilei speaking. To whom do I have the privilege of speaking"
}
```